### PR TITLE
chore: add dependencies, modify CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,8 +20,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: pnpm
-      - run: pnpm install
-      - run: pnpm run build
+      - run: pnpm build
         env:
           NODE_OPTIONS: --max_old_space_size=4096
       - uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,10 +1,7 @@
-
 name: 部署文档
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   build:
@@ -24,9 +21,11 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=4096
       - uses: actions/upload-pages-artifact@v1
+        if: github.ref == 'refs/heads/main'
         with:
           path: docs/.vuepress/dist
   deploy:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-20.04
     needs: build
     permissions:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,6 +2,8 @@ name: 部署文档
 
 on:
   push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -21,11 +23,9 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=4096
       - uses: actions/upload-pages-artifact@v1
-        if: github.ref == 'refs/heads/main'
         with:
           path: docs/.vuepress/dist
   deploy:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-20.04
     needs: build
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: 测试
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+          run_install: true
+      - uses: actions/setup-node@v3
+        with:
+          cache: pnpm
+      - run: pnpm build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "dev": "vuepress dev docs"
   },
   "devDependencies": {
+    "@types/markdown-it": "^13.0.0",
     "@vuepress/client": "2.0.0-beta.62",
+    "markdown-it-pangu": "^1.0.2",
     "vue": "^3.3.4",
     "vuepress": "2.0.0-beta.62",
     "vuepress-theme-hope": "2.0.0-beta.219"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,13 +1,19 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 devDependencies:
+  '@types/markdown-it':
+    specifier: ^13.0.0
+    version: 13.0.0
   '@vuepress/client':
     specifier: 2.0.0-beta.62
     version: 2.0.0-beta.62
+  markdown-it-pangu:
+    specifier: ^1.0.2
+    version: 1.0.2
   vue:
     specifier: ^3.3.4
     version: 3.3.4
@@ -1860,11 +1866,18 @@ packages:
   /@types/markdown-it-emoji@2.0.2:
     resolution: {integrity: sha512-2ln8Wjbcj/0oRi/6VnuMeWEHHuK8uapFttvcLmDIe1GKCsFBLOLBX+D+xhDa9oWOQV0IpvxwrSfKKssAqqroog==}
     dependencies:
-      '@types/markdown-it': 12.2.3
+      '@types/markdown-it': 13.0.0
     dev: true
 
   /@types/markdown-it@12.2.3:
     resolution: {integrity: sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==}
+    dependencies:
+      '@types/linkify-it': 3.0.2
+      '@types/mdurl': 1.0.2
+    dev: true
+
+  /@types/markdown-it@13.0.0:
+    resolution: {integrity: sha512-mPTaUl5glYfzdJFeCsvhXQwZKdyszNAZcMm5ZTP5SfpTu+vIbog7J3z8Fa4x/Fzv5TB4R6OA/pHBYIYmkYOWGQ==}
     dependencies:
       '@types/linkify-it': 3.0.2
       '@types/mdurl': 1.0.2
@@ -3259,6 +3272,10 @@ packages:
     resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
     dev: true
 
+  /entities@1.1.2:
+    resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
+    dev: true
+
   /entities@3.0.1:
     resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
     engines: {node: '>=0.12'}
@@ -4108,6 +4125,12 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /linkify-it@2.2.0:
+    resolution: {integrity: sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==}
+    dependencies:
+      uc.micro: 1.0.6
+    dev: true
+
   /linkify-it@4.0.1:
     resolution: {integrity: sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==}
     dependencies:
@@ -4221,6 +4244,13 @@ packages:
     resolution: {integrity: sha512-zLftSaNrKuYl0kR5zm4gxXjHaOI3FAOEaloKmRA5hijmJZvSjmxcokOLlzycb/HXlUFWzXqpIEoyEMCE4i9MvQ==}
     dev: true
 
+  /markdown-it-pangu@1.0.2:
+    resolution: {integrity: sha512-rssyYaMKXRLMpQIUgX01VE1KYOHhlnc4t5zGTI2zgXDpE88eQz8hywa0iSzoFm3eb5CYzFWazDKdUbnyZvW0SQ==}
+    dependencies:
+      markdown-it: 8.4.2
+      pangu: 4.0.7
+    dev: true
+
   /markdown-it@13.0.1:
     resolution: {integrity: sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==}
     hasBin: true
@@ -4228,6 +4258,17 @@ packages:
       argparse: 2.0.1
       entities: 3.0.1
       linkify-it: 4.0.1
+      mdurl: 1.0.1
+      uc.micro: 1.0.6
+    dev: true
+
+  /markdown-it@8.4.2:
+    resolution: {integrity: sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      entities: 1.1.2
+      linkify-it: 2.2.0
       mdurl: 1.0.1
       uc.micro: 1.0.6
     dev: true
@@ -4667,6 +4708,11 @@ packages:
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+    dev: true
+
+  /pangu@4.0.7:
+    resolution: {integrity: sha512-weZKJIwwy5gjt4STGVUH9bix3BGk7wZ2ahtIypwe3e/mllsrIZIvtfLx1dPX56GcpZFOCFKmeqI1qVuB9enRzA==}
+    hasBin: true
     dev: true
 
   /parse5-htmlparser2-tree-adapter@7.0.0:


### PR DESCRIPTION
- 修复了 `pangu` 未添加至 `package.json` 的问题
- CI 中已指定在安装 pnpm 时安装依赖项，不需要再运行 `pnpm install`。
- 在所有 branch 中都运行 build 以进行简单的 Smoke Test，只在 main 分支运行 deploy。