### PR TITLE
🎨 Disable comment

### DIFF
--- a/docs/.vuepress/theme.ts
+++ b/docs/.vuepress/theme.ts
@@ -35,15 +35,7 @@ export default hopeTheme({
     feed: {
       rss: true,
     },
-    comment: {
-      provider: "Waline",
-      serverURL: "https://waline.rle.wiki",
-      dark: "auto",
-      requiredMeta: ['nick', 'mail'],
-      locale: {
-        admin: "编辑组"
-      }
-    },
+    comment: false,
     mdEnhance: {
       container: true,
       tabs: true,


### PR DESCRIPTION
原有的 Waline 评论系统事实上一直处于失效状态。根据 https://github.com/project-trans/RLE-wiki/pull/144#issuecomment-1697088794 ，在并不准备开启评论区的情况下，不再显示评论区。