### PR TITLE
修正新版 RLE.wiki 首页标题中英文空格问题 #260

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -5,7 +5,7 @@ import theme from "./theme";
 export default defineUserConfig({
   lang: "zh-CN",
   title: "RLE.wiki",
-  description: "一份RLE指北",
+  description: "一份 RLE 指北",
 
   base: "/",
 


### PR DESCRIPTION
~~还记得 #260 吗？这里还是我（~~

修正了新版 RLE.wiki 首页中标题中英文空格的问题