### PR TITLE
fix: page title not found in search

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -75,6 +75,15 @@ export default defineConfig({
             },
           },
         },
+        // Add title field in frontmatter to search
+        // You can exclude a page from search by adding search: false to the page's frontmatter.
+        _render(src, env, md) {
+          if (env.frontmatter?.search === false) return ''
+          let html = md.render(src, env)
+          if (env.frontmatter?.title)
+            html = md.render(`# ${env.frontmatter.title}\n`) + html
+          return html
+        },
       },
     },
   },


### PR DESCRIPTION
![image](https://github.com/project-trans/RLE-wiki/assets/19204772/89abcd08-0034-4d58-8d16-520b40609d5b)
