### PR TITLE
更新搜索框翻译，添加 ARIA 标签

### DIFF
--- a/packages/vitepress-theme-project-trans/src/config.ts
+++ b/packages/vitepress-theme-project-trans/src/config.ts
@@ -107,6 +107,11 @@ function genConfig() {
                     selectText: '选择',
                     navigateText: '切换',
                     closeText: '关闭',
+                    // 无障碍（ARIA）标签，用于描述键盘导航操作
+                    navigateUpKeyAriaLabel: '上箭头',
+                    navigateDownKeyAriaLabel: '下箭头',
+                    selectKeyAriaLabel: '回车',
+                    closeKeyAriaLabel: '退出'
                   },
                 },
               },

--- a/packages/vitepress-theme-project-trans/src/config.ts
+++ b/packages/vitepress-theme-project-trans/src/config.ts
@@ -102,9 +102,11 @@ function genConfig() {
                 modal: {
                   noResultsText: '无法找到相关结果',
                   resetButtonTitle: '清除查询条件',
+                  displayDetails: '显示详细列表',
                   footer: {
                     selectText: '选择',
                     navigateText: '切换',
+                    closeText: '关闭',
                   },
                 },
               },


### PR DESCRIPTION
更新搜索框页脚和按钮的翻译，加入了无障碍（ARIA）标签
原版本
![image](https://github.com/user-attachments/assets/e1169850-2c99-47a5-9db3-841f166a0df1)
更新后
![image](https://github.com/user-attachments/assets/c7deaef8-cc2d-4c83-b95c-95abdb49826d)
