### PR TITLE
添加PR通知功能

### DIFF
--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -15,7 +15,7 @@ jobs:
           server_port: 465
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
-          subject: "【LindongNote】新的 PR 请求 #${{ github.event.pull_request.number }}"
+          subject: "【Project-Trans-Bot】新的 PR 请求 #${{ github.event.pull_request.number }}"
           to: ${{ secrets.TEAM_EMAILS }}
           from: ${{ secrets.MAIL_USERNAME }}
           body: |

--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -1,0 +1,29 @@
+name: PR 邮件通知
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 发送邮件通知
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.feishu.cn
+          server_port: 465
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: "【LindongNote】新的 PR 请求 #${{ github.event.pull_request.number }}"
+          to: ${{ secrets.TEAM_EMAILS }}
+          from: ${{ secrets.MAIL_USERNAME }}
+          body: |
+            有新的 PR 需要审核：
+            
+            标题：${{ github.event.pull_request.title }}
+            作者：${{ github.event.pull_request.user.login }}
+            
+            PR 链接：${{ github.event.pull_request.html_url }}
+            
+            请及时审核。


### PR DESCRIPTION
这个功能是，当有新的PR创建时用邮件通知审核人员，注意在本分支合并之前必须添加以下：
secrets.MAIL_USERNAME（示例：notify@project-trans.org）
secrets.MAIL_PASSWORD
secrets.TEAM_EMAILS（可以是一个也可以是多个，多个之间用逗号隔开）
成果展示：
<img width="387" alt="image" src="https://github.com/user-attachments/assets/3e7416bf-7436-42c3-b4c0-4ff7504002c8" />
所有的功能我都已经测试正常，可以放心